### PR TITLE
Updated license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "epoch",
   "version": "1.0.0",
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "scripts": {
     "dev": "next",
     "build": "next build",


### PR DESCRIPTION
I noticed the main project license was listed as MIT, and the package.json still said ISC. I figure this was a mistake?